### PR TITLE
[Dask] Adding two tests for Dask in MLRun

### DIFF
--- a/test-dask-lightgbm/test-dask-lightgbm.ipynb
+++ b/test-dask-lightgbm/test-dask-lightgbm.ipynb
@@ -1,0 +1,1117 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "33ae8b7f",
+   "metadata": {},
+   "source": [
+    "# Training A LightGBM Classifier With And Without Dask\n",
+    "\n",
+    "This test generates a big binarry classification data for later train a model on the generated data using LightGBM with and without Dask. Later it will verify that:\n",
+    "  * The accuracy was not damaged in Dask.\n",
+    "  * The dask training run was faster. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eee58549",
+   "metadata": {},
+   "source": [
+    "## General Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "402696ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Path to store the generated data:\n",
+    "DATA_PATH = \"./data\"\n",
+    "\n",
+    "# Number of samples of generated data (number of rows in the data table):\n",
+    "N_SAMPLES = 2_000_000\n",
+    "\n",
+    "# Number of features of the generated data (number of columns in the data table):\n",
+    "N_FEATURES = 40\n",
+    "\n",
+    "# The percentage of data to be labeled as a testing set:\n",
+    "TRAIN_TEST_SPLIT = 0.33\n",
+    "\n",
+    "# The amount of parquet partitions to have of the generated data:\n",
+    "N_PARTITIONS = 20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "83c127f2",
+   "metadata": {},
+   "source": [
+    "## 1. Generate Data:\n",
+    "\n",
+    "1. Generate a binary classification data.\n",
+    "2. Turn the data into a `pandas.DataFrame` naming the columns `features_{i}` and adding the partioting column (year).\n",
+    "3. Split the data into a training and testing sets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "6fd0645b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "def generate_data(\n",
+    "    output_path: str,\n",
+    "    n_samples: int, \n",
+    "    n_features: int, \n",
+    "    test_size: float, \n",
+    "    n_partitions: int,\n",
+    "):\n",
+    "    # Generate data:\n",
+    "    x, y = make_classification(\n",
+    "        n_samples=n_samples, \n",
+    "        n_features=n_features, \n",
+    "        n_informative=int(n_features / 4) + 1, \n",
+    "        n_classes=2, \n",
+    "        n_redundant=int(n_features / 10) + 1,\n",
+    "    )\n",
+    "    \n",
+    "    # Create a dataframe:\n",
+    "    data = pd.DataFrame(\n",
+    "        data=x, \n",
+    "        columns=[f\"feature_{i}\" for i in range(n_features)]\n",
+    "    )\n",
+    "    data[\"year\"] = np.random.randint(2000, 2000 + n_partitions, size=n_samples)\n",
+    "    data[\"label\"] = y\n",
+    "    \n",
+    "    # Split into train and test sets:\n",
+    "    train_set, test_set = train_test_split(data, test_size=test_size)\n",
+    "    \n",
+    "    # Save to parquets:\n",
+    "    train_set.to_parquet(f\"{output_path}/train\", partition_cols=[\"year\"])\n",
+    "    test_set.to_parquet(f\"{output_path}/test\", partition_cols=[\"year\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ed3b98f",
+   "metadata": {},
+   "source": [
+    "Generate the data (will require writing permissions to the local directory)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "1019e871",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete past generated data (in case there was a failure):\n",
+    "if os.path.exists(DATA_PATH):\n",
+    "    shutil.rmtree(os.path.abspath(DATA_PATH))\n",
+    "\n",
+    "# Generate new data:\n",
+    "generate_data(\n",
+    "    output_path=DATA_PATH,\n",
+    "    n_samples=N_SAMPLES, \n",
+    "    n_features=N_FEATURES, \n",
+    "    test_size=TRAIN_TEST_SPLIT,\n",
+    "    n_partitions=N_PARTITIONS,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ad7beac3",
+   "metadata": {},
+   "source": [
+    "## 2. Training Code\n",
+    "\n",
+    "1. Read the data into a pandas (dask) `DataFrame`.\n",
+    "2. Split the data into `x` and `y`.\n",
+    "3. Initialize a `LGBMClassifier` (`DaskLGBMClassifier`) model.\n",
+    "4. Run training on the training set.\n",
+    "5. Run evaluation on the testing set.\n",
+    "\n",
+    "Accuracy score will be logged as a result."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "93d07200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# mlrun: start-code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0aaa1d76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import dask\n",
+    "import lightgbm as lgb\n",
+    "from sklearn.metrics import accuracy_score\n",
+    "import mlrun\n",
+    "import mlrun.frameworks.lgbm as mlrun_lgbm\n",
+    "\n",
+    "\n",
+    "@mlrun.handler(outputs=[\"accuracy_score\"])\n",
+    "def train(context: mlrun.MLClientCtx, data_path: str):\n",
+    "    # Check for a dask client:\n",
+    "    dask_function = context.get_param(\"dask_function\", None)\n",
+    "    dask_client = mlrun.import_function(dask_function).client if dask_function else None\n",
+    "    \n",
+    "    # Get the data:\n",
+    "    read_parquet_function = dask.dataframe.read_parquet if dask_client else pd.read_parquet\n",
+    "    train_set = read_parquet_function(f\"{data_path}/train\")\n",
+    "    if dask_client:\n",
+    "        train_set = dask_client.persist(train_set)\n",
+    "    test_set = read_parquet_function(f\"{data_path}/test\")\n",
+    "    if dask_client:\n",
+    "        test_set = dask_client.persist(test_set)\n",
+    "    \n",
+    "    # Split into x and y:\n",
+    "    y_train = train_set.label\n",
+    "    x_train = train_set.drop(columns=[\"label\"])\n",
+    "    y_test = test_set.label\n",
+    "    x_test = test_set.drop(columns=[\"label\"])\n",
+    "    \n",
+    "    # Initialize a model:\n",
+    "    model = lgb.DaskLGBMClassifier(client=dask_client) if dask_client else lgb.LGBMClassifier()\n",
+    "    \n",
+    "    # Train:\n",
+    "    model.fit(x_train, y_train)\n",
+    "    \n",
+    "    # Predict:\n",
+    "    y_pred = model.predict(x_test)\n",
+    "    \n",
+    "    # Evaluate:\n",
+    "    if dask_client:\n",
+    "        y_test = y_test.compute()\n",
+    "        y_pred = y_pred.compute()\n",
+    "    return accuracy_score(y_pred, y_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "ec66a1b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# mlrun: end-code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e6a584",
+   "metadata": {},
+   "source": [
+    "## 3. Create a Project\n",
+    "\n",
+    "1. Create the MLRun project.\n",
+    "2. Use MLRun's `code_to_function` to create an MLRun function of the training code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "585bdc64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import time\n",
+    "\n",
+    "import mlrun"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "c76ae8a1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:27:08,036 [info] loaded project dask-lightgbm-test from MLRun DB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create the project:\n",
+    "project = mlrun.get_or_create_project(\n",
+    "    name=\"dask-lightgbm-test\", \n",
+    "    context=\"./\", \n",
+    "    user_project=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "fd7add18",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<mlrun.runtimes.kubejob.KubejobRuntime at 0x7fd9a61f1e90>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create the training function:\n",
+    "train_function = mlrun.code_to_function(\n",
+    "    name=\"train\",\n",
+    "    kind=\"job\",\n",
+    "    image=\"mlrun/ml-models\",\n",
+    "    handler=\"train\",\n",
+    ")\n",
+    "train_function.apply(mlrun.auto_mount())\n",
+    "\n",
+    "# Assign the function to the project:\n",
+    "project.set_function(train_function)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "561e6564",
+   "metadata": {},
+   "source": [
+    "## 4. Run Without Dask\n",
+    "\n",
+    "Run the training without Dask while timing it and storing the accuracy score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "5af6317f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:27:15,091 [info] starting run without_dask uid=b3650e799a9f4870bc91c1790ed0f1a8 DB=http://mlrun-api:8080\n",
+      "> 2022-12-18 11:27:15,284 [info] Job is running in the background, pod: without-dask-6pwxl\n",
+      "> 2022-12-18 11:30:36,556 [info] To track results use the CLI: {'info_cmd': 'mlrun get run b3650e799a9f4870bc91c1790ed0f1a8 -p dask-lightgbm-test-guyl', 'logs_cmd': 'mlrun logs b3650e799a9f4870bc91c1790ed0f1a8 -p dask-lightgbm-test-guyl'}\n",
+      "> 2022-12-18 11:30:36,557 [info] Or click for UI: {'ui_url': 'https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/dask-lightgbm-test-guyl/jobs/monitor/b3650e799a9f4870bc91c1790ed0f1a8/overview'}\n",
+      "> 2022-12-18 11:30:36,557 [info] run executed, status=completed\n",
+      "final state: completed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".dictlist {\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: center;\n",
+       "  margin: 4px;\n",
+       "  border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}\n",
+       ".artifact {\n",
+       "  cursor: pointer;\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: left;\n",
+       "  margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;\n",
+       "}\n",
+       "div.block.hidden {\n",
+       "  display: none;\n",
+       "}\n",
+       ".clickable {\n",
+       "  cursor: pointer;\n",
+       "}\n",
+       ".ellipsis {\n",
+       "  display: inline-block;\n",
+       "  max-width: 60px;\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "}\n",
+       ".master-wrapper {\n",
+       "  display: flex;\n",
+       "  flex-flow: row nowrap;\n",
+       "  justify-content: flex-start;\n",
+       "  align-items: stretch;\n",
+       "}\n",
+       ".master-tbl {\n",
+       "  flex: 3\n",
+       "}\n",
+       ".master-wrapper > div {\n",
+       "  margin: 4px;\n",
+       "  padding: 10px;\n",
+       "}\n",
+       "iframe.fileview {\n",
+       "  border: 0 none;\n",
+       "  height: 100%;\n",
+       "  width: 100%;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       ".pane-header-title {\n",
+       "  width: 80%;\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       ".pane-header {\n",
+       "  line-height: 1;\n",
+       "  background-color: #4EC64B;\n",
+       "  padding: 3px;\n",
+       "}\n",
+       ".pane-header .close {\n",
+       "  font-size: 20px;\n",
+       "  font-weight: 700;\n",
+       "  float: right;\n",
+       "  margin-top: -5px;\n",
+       "}\n",
+       ".master-wrapper .right-pane {\n",
+       "  border: 1px inset silver;\n",
+       "  width: 40%;\n",
+       "  min-height: 300px;\n",
+       "  flex: 3\n",
+       "  min-width: 500px;\n",
+       "}\n",
+       ".master-wrapper * {\n",
+       "  box-sizing: border-box;\n",
+       "}\n",
+       "</style><script>\n",
+       "function copyToClipboard(fld) {\n",
+       "    if (document.queryCommandSupported && document.queryCommandSupported('copy')) {\n",
+       "        var textarea = document.createElement('textarea');\n",
+       "        textarea.textContent = fld.innerHTML;\n",
+       "        textarea.style.position = 'fixed';\n",
+       "        document.body.appendChild(textarea);\n",
+       "        textarea.select();\n",
+       "\n",
+       "        try {\n",
+       "            return document.execCommand('copy'); // Security exception may be thrown by some browsers.\n",
+       "        } catch (ex) {\n",
+       "\n",
+       "        } finally {\n",
+       "            document.body.removeChild(textarea);\n",
+       "        }\n",
+       "    }\n",
+       "}\n",
+       "function expandPanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName');\n",
+       "  console.log(el.title);\n",
+       "\n",
+       "  document.querySelector(panelName + \"-title\").innerHTML = el.title\n",
+       "  iframe = document.querySelector(panelName + \"-body\");\n",
+       "\n",
+       "  const tblcss = `<style> body { font-family: Arial, Helvetica, sans-serif;}\n",
+       "    #csv { margin-bottom: 15px; }\n",
+       "    #csv table { border-collapse: collapse;}\n",
+       "    #csv table td { padding: 4px 8px; border: 1px solid silver;} </style>`;\n",
+       "\n",
+       "  function csvToHtmlTable(str) {\n",
+       "    return '<div id=\"csv\"><table><tr><td>' +  str.replace(/[\\n\\r]+$/g, '').replace(/[\\n\\r]+/g, '</td></tr><tr><td>')\n",
+       "      .replace(/,/g, '</td><td>') + '</td></tr></table></div>';\n",
+       "  }\n",
+       "\n",
+       "  function reqListener () {\n",
+       "    if (el.title.endsWith(\".csv\")) {\n",
+       "      iframe.setAttribute(\"srcdoc\", tblcss + csvToHtmlTable(this.responseText));\n",
+       "    } else {\n",
+       "      iframe.setAttribute(\"srcdoc\", this.responseText);\n",
+       "    }\n",
+       "    console.log(this.responseText);\n",
+       "  }\n",
+       "\n",
+       "  const oReq = new XMLHttpRequest();\n",
+       "  oReq.addEventListener(\"load\", reqListener);\n",
+       "  oReq.open(\"GET\", el.title);\n",
+       "  oReq.send();\n",
+       "\n",
+       "\n",
+       "  //iframe.src = el.title;\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.remove(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "function closePanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName')\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (!resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.add(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "\n",
+       "</script>\n",
+       "<div class=\"master-wrapper\">\n",
+       "  <div class=\"block master-tbl\"><div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>project</th>\n",
+       "      <th>uid</th>\n",
+       "      <th>iter</th>\n",
+       "      <th>start</th>\n",
+       "      <th>state</th>\n",
+       "      <th>name</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>inputs</th>\n",
+       "      <th>parameters</th>\n",
+       "      <th>results</th>\n",
+       "      <th>artifacts</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>dask-lightgbm-test-guyl</td>\n",
+       "      <td><div title=\"b3650e799a9f4870bc91c1790ed0f1a8\"><a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/dask-lightgbm-test-guyl/jobs/monitor/b3650e799a9f4870bc91c1790ed0f1a8/overview\" target=\"_blank\" >...0ed0f1a8</a></div></td>\n",
+       "      <td>0</td>\n",
+       "      <td>Dec 18 11:27:21</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>without_dask</td>\n",
+       "      <td><div class=\"dictlist\">v3io_user=guyl</div><div class=\"dictlist\">kind=job</div><div class=\"dictlist\">owner=guyl</div><div class=\"dictlist\">mlrun/client_version=1.2.1-rc4</div><div class=\"dictlist\">host=without-dask-6pwxl</div></td>\n",
+       "      <td></td>\n",
+       "      <td><div class=\"dictlist\">data_path=/User/dask/data</div><div class=\"dictlist\">dask_function=None</div></td>\n",
+       "      <td><div class=\"dictlist\">accuracy_score=0.9708757575757576</div></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div></div>\n",
+       "  <div id=\"result654e572f-pane\" class=\"right-pane block hidden\">\n",
+       "    <div class=\"pane-header\">\n",
+       "      <span id=\"result654e572f-title\" class=\"pane-header-title\">Title</span>\n",
+       "      <span onclick=\"closePanel(this)\" paneName=\"result654e572f\" class=\"close clickable\">&times;</span>\n",
+       "    </div>\n",
+       "    <iframe class=\"fileview\" id=\"result654e572f-body\"></iframe>\n",
+       "  </div>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<b> > to track results use the .show() or .logs() methods  or <a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/dask-lightgbm-test-guyl/jobs/monitor/b3650e799a9f4870bc91c1790ed0f1a8/overview\" target=\"_blank\">click here</a> to open in UI</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:30:38,391 [info] run executed, status=completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "without_dask_time = time.time()\n",
+    "without_dask_run = train_function.run(\n",
+    "    name=\"without_dask\",\n",
+    "    params={\n",
+    "        \"data_path\": os.path.abspath(DATA_PATH),\n",
+    "    },\n",
+    ")\n",
+    "without_dask_time = time.time() - without_dask_time\n",
+    "without_dask_score = without_dask_run.status.results['accuracy_score']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78a942a0",
+   "metadata": {},
+   "source": [
+    "## 5. Run With Dask\n",
+    "\n",
+    "1. Create the Dask function.\n",
+    "2. Configure it.\n",
+    "3. Run the training with Dask while timing it and storing the accuracy score."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "3dad803a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'db://dask-lightgbm-test-guyl/my-dask'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create the dask function:\n",
+    "dask_function = mlrun.new_function(name=\"my_dask\", kind=\"dask\", image=\"mlrun/ml-models\")\n",
+    "\n",
+    "# Configure the dask function specs:\n",
+    "dask_function.spec.remote = True\n",
+    "dask_function.spec.replicas = 5\n",
+    "dask_function.spec.service_type = 'NodePort'\n",
+    "dask_function.with_limits(mem=\"6G\")\n",
+    "dask_function.spec.nthreads = 5\n",
+    "dask_function.apply(mlrun.auto_mount())\n",
+    "\n",
+    "# Assign the function to the project:\n",
+    "project.set_function(dask_function)\n",
+    "\n",
+    "# Save:\n",
+    "dask_function.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "b608b285",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:30:49,764 [info] trying dask client at: tcp://mlrun-my-dask-8c166765-e.default-tenant:8786\n",
+      "> 2022-12-18 11:30:49,807 [info] using remote dask scheduler (mlrun-my-dask-8c166765-e) at: tcp://mlrun-my-dask-8c166765-e.default-tenant:8786\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Mismatched versions found\n",
+      "\n",
+      "+-------------+--------+-----------+---------+\n",
+      "| Package     | client | scheduler | workers |\n",
+      "+-------------+--------+-----------+---------+\n",
+      "| blosc       | 1.7.0  | 1.10.6    | None    |\n",
+      "| cloudpickle | 2.0.0  | 2.2.0     | None    |\n",
+      "| lz4         | 3.1.0  | 3.1.10    | None    |\n",
+      "| msgpack     | 1.0.3  | 1.0.4     | None    |\n",
+      "| toolz       | 0.11.2 | 0.12.0    | None    |\n",
+      "| tornado     | 6.1    | 6.2       | None    |\n",
+      "+-------------+--------+-----------+---------+\n",
+      "Notes: \n",
+      "-  msgpack: Variation is ok, as long as everything is above 0.6\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"http://default-tenant.app.dev6.lab.iguazeng.com:32162/status\" target=\"_blank\" >dashboard link: default-tenant.app.dev6.lab.iguazeng.com:32162</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\"> </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h3 style=\"margin-bottom: 0px;\">Client</h3>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-6c3def38-7ec7-11ed-b396-0dc2946228f4</p>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "\n",
+       "        <tr>\n",
+       "        \n",
+       "            <td style=\"text-align: left;\"><strong>Connection method:</strong> Direct</td>\n",
+       "            <td style=\"text-align: left;\"></td>\n",
+       "        \n",
+       "        </tr>\n",
+       "\n",
+       "        \n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Dashboard: </strong> <a href=\"http://mlrun-my-dask-8c166765-e.default-tenant:8787/status\" target=\"_blank\">http://mlrun-my-dask-8c166765-e.default-tenant:8787/status</a>\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\"></td>\n",
+       "            </tr>\n",
+       "        \n",
+       "\n",
+       "        </table>\n",
+       "\n",
+       "        \n",
+       "            <details>\n",
+       "            <summary style=\"margin-bottom: 20px;\"><h3 style=\"display: inline;\">Scheduler Info</h3></summary>\n",
+       "            <div style=\"\">\n",
+       "    <div>\n",
+       "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
+       "        <div style=\"margin-left: 48px;\">\n",
+       "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-2f343a04-fd6f-47a8-a060-0c9f663d339c</p>\n",
+       "            <table style=\"width: 100%; text-align: left;\">\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Comm:</strong> tcp://10.201.103.59:8786\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Workers:</strong> 0\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Dashboard:</strong> <a href=\"http://10.201.103.59:8787/status\" target=\"_blank\">http://10.201.103.59:8787/status</a>\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total threads:</strong> 0\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Started:</strong> Just now\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total memory:</strong> 0 B\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "            </table>\n",
+       "        </div>\n",
+       "    </div>\n",
+       "\n",
+       "    <details style=\"margin-left: 48px;\">\n",
+       "        <summary style=\"margin-bottom: 20px;\">\n",
+       "            <h3 style=\"display: inline;\">Workers</h3>\n",
+       "        </summary>\n",
+       "\n",
+       "        \n",
+       "\n",
+       "    </details>\n",
+       "</div>\n",
+       "            </details>\n",
+       "        \n",
+       "\n",
+       "    </div>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "<Client: 'tcp://10.201.103.59:8786' processes=0 threads=0, memory=0 B>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dask_function.client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "e5bf9469",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:30:49,903 [info] starting run with_dask uid=6a4d8b5d69364074b7a7354b4f5c4c1d DB=http://mlrun-api:8080\n",
+      "> 2022-12-18 11:30:50,101 [info] Job is running in the background, pod: with-dask-8q8zf\n",
+      "> 2022-12-18 11:31:00,882 [info] trying dask client at: tcp://mlrun-my-dask-8c166765-e.default-tenant:8786\n",
+      "> 2022-12-18 11:31:00,918 [info] using remote dask scheduler (mlrun-my-dask-8c166765-e) at: tcp://mlrun-my-dask-8c166765-e.default-tenant:8786\n",
+      "remote dashboard: default-tenant.app.dev6.lab.iguazeng.com:32162\n",
+      "Finding random open ports for workers\n",
+      "> 2022-12-18 11:31:45,259 [info] To track results use the CLI: {'info_cmd': 'mlrun get run 6a4d8b5d69364074b7a7354b4f5c4c1d -p dask-lightgbm-test-guyl', 'logs_cmd': 'mlrun logs 6a4d8b5d69364074b7a7354b4f5c4c1d -p dask-lightgbm-test-guyl'}\n",
+      "> 2022-12-18 11:31:45,259 [info] Or click for UI: {'ui_url': 'https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/dask-lightgbm-test-guyl/jobs/monitor/6a4d8b5d69364074b7a7354b4f5c4c1d/overview'}\n",
+      "> 2022-12-18 11:31:45,260 [info] run executed, status=completed\n",
+      "Parameter n_jobs will be ignored.\n",
+      "final state: completed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".dictlist {\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: center;\n",
+       "  margin: 4px;\n",
+       "  border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}\n",
+       ".artifact {\n",
+       "  cursor: pointer;\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: left;\n",
+       "  margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;\n",
+       "}\n",
+       "div.block.hidden {\n",
+       "  display: none;\n",
+       "}\n",
+       ".clickable {\n",
+       "  cursor: pointer;\n",
+       "}\n",
+       ".ellipsis {\n",
+       "  display: inline-block;\n",
+       "  max-width: 60px;\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "}\n",
+       ".master-wrapper {\n",
+       "  display: flex;\n",
+       "  flex-flow: row nowrap;\n",
+       "  justify-content: flex-start;\n",
+       "  align-items: stretch;\n",
+       "}\n",
+       ".master-tbl {\n",
+       "  flex: 3\n",
+       "}\n",
+       ".master-wrapper > div {\n",
+       "  margin: 4px;\n",
+       "  padding: 10px;\n",
+       "}\n",
+       "iframe.fileview {\n",
+       "  border: 0 none;\n",
+       "  height: 100%;\n",
+       "  width: 100%;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       ".pane-header-title {\n",
+       "  width: 80%;\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       ".pane-header {\n",
+       "  line-height: 1;\n",
+       "  background-color: #4EC64B;\n",
+       "  padding: 3px;\n",
+       "}\n",
+       ".pane-header .close {\n",
+       "  font-size: 20px;\n",
+       "  font-weight: 700;\n",
+       "  float: right;\n",
+       "  margin-top: -5px;\n",
+       "}\n",
+       ".master-wrapper .right-pane {\n",
+       "  border: 1px inset silver;\n",
+       "  width: 40%;\n",
+       "  min-height: 300px;\n",
+       "  flex: 3\n",
+       "  min-width: 500px;\n",
+       "}\n",
+       ".master-wrapper * {\n",
+       "  box-sizing: border-box;\n",
+       "}\n",
+       "</style><script>\n",
+       "function copyToClipboard(fld) {\n",
+       "    if (document.queryCommandSupported && document.queryCommandSupported('copy')) {\n",
+       "        var textarea = document.createElement('textarea');\n",
+       "        textarea.textContent = fld.innerHTML;\n",
+       "        textarea.style.position = 'fixed';\n",
+       "        document.body.appendChild(textarea);\n",
+       "        textarea.select();\n",
+       "\n",
+       "        try {\n",
+       "            return document.execCommand('copy'); // Security exception may be thrown by some browsers.\n",
+       "        } catch (ex) {\n",
+       "\n",
+       "        } finally {\n",
+       "            document.body.removeChild(textarea);\n",
+       "        }\n",
+       "    }\n",
+       "}\n",
+       "function expandPanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName');\n",
+       "  console.log(el.title);\n",
+       "\n",
+       "  document.querySelector(panelName + \"-title\").innerHTML = el.title\n",
+       "  iframe = document.querySelector(panelName + \"-body\");\n",
+       "\n",
+       "  const tblcss = `<style> body { font-family: Arial, Helvetica, sans-serif;}\n",
+       "    #csv { margin-bottom: 15px; }\n",
+       "    #csv table { border-collapse: collapse;}\n",
+       "    #csv table td { padding: 4px 8px; border: 1px solid silver;} </style>`;\n",
+       "\n",
+       "  function csvToHtmlTable(str) {\n",
+       "    return '<div id=\"csv\"><table><tr><td>' +  str.replace(/[\\n\\r]+$/g, '').replace(/[\\n\\r]+/g, '</td></tr><tr><td>')\n",
+       "      .replace(/,/g, '</td><td>') + '</td></tr></table></div>';\n",
+       "  }\n",
+       "\n",
+       "  function reqListener () {\n",
+       "    if (el.title.endsWith(\".csv\")) {\n",
+       "      iframe.setAttribute(\"srcdoc\", tblcss + csvToHtmlTable(this.responseText));\n",
+       "    } else {\n",
+       "      iframe.setAttribute(\"srcdoc\", this.responseText);\n",
+       "    }\n",
+       "    console.log(this.responseText);\n",
+       "  }\n",
+       "\n",
+       "  const oReq = new XMLHttpRequest();\n",
+       "  oReq.addEventListener(\"load\", reqListener);\n",
+       "  oReq.open(\"GET\", el.title);\n",
+       "  oReq.send();\n",
+       "\n",
+       "\n",
+       "  //iframe.src = el.title;\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.remove(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "function closePanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName')\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (!resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.add(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "\n",
+       "</script>\n",
+       "<div class=\"master-wrapper\">\n",
+       "  <div class=\"block master-tbl\"><div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>project</th>\n",
+       "      <th>uid</th>\n",
+       "      <th>iter</th>\n",
+       "      <th>start</th>\n",
+       "      <th>state</th>\n",
+       "      <th>name</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>inputs</th>\n",
+       "      <th>parameters</th>\n",
+       "      <th>results</th>\n",
+       "      <th>artifacts</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>dask-lightgbm-test-guyl</td>\n",
+       "      <td><div title=\"6a4d8b5d69364074b7a7354b4f5c4c1d\"><a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/dask-lightgbm-test-guyl/jobs/monitor/6a4d8b5d69364074b7a7354b4f5c4c1d/overview\" target=\"_blank\" >...4f5c4c1d</a></div></td>\n",
+       "      <td>0</td>\n",
+       "      <td>Dec 18 11:30:58</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>with_dask</td>\n",
+       "      <td><div class=\"dictlist\">v3io_user=guyl</div><div class=\"dictlist\">kind=job</div><div class=\"dictlist\">owner=guyl</div><div class=\"dictlist\">mlrun/client_version=1.2.1-rc4</div><div class=\"dictlist\">host=with-dask-8q8zf</div></td>\n",
+       "      <td></td>\n",
+       "      <td><div class=\"dictlist\">data_path=/User/dask/data</div><div class=\"dictlist\">dask_function=db://dask-lightgbm-test-guyl/my-dask</div></td>\n",
+       "      <td><div class=\"dictlist\">accuracy_score=0.970410606060606</div></td>\n",
+       "      <td></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div></div>\n",
+       "  <div id=\"result81c0f123-pane\" class=\"right-pane block hidden\">\n",
+       "    <div class=\"pane-header\">\n",
+       "      <span id=\"result81c0f123-title\" class=\"pane-header-title\">Title</span>\n",
+       "      <span onclick=\"closePanel(this)\" paneName=\"result81c0f123\" class=\"close clickable\">&times;</span>\n",
+       "    </div>\n",
+       "    <iframe class=\"fileview\" id=\"result81c0f123-body\"></iframe>\n",
+       "  </div>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<b> > to track results use the .show() or .logs() methods  or <a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/dask-lightgbm-test-guyl/jobs/monitor/6a4d8b5d69364074b7a7354b4f5c4c1d/overview\" target=\"_blank\">click here</a> to open in UI</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:31:50,190 [info] run executed, status=completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "with_dask_time = time.time()\n",
+    "with_dask_run = train_function.run(\n",
+    "    name=\"with_dask\",\n",
+    "    params={\n",
+    "        \"data_path\": os.path.abspath(DATA_PATH),\n",
+    "        \"dask_function\": \"db://\" + dask_function.uri,\n",
+    "    },\n",
+    ")\n",
+    "with_dask_time = time.time() - with_dask_time\n",
+    "with_dask_score = with_dask_run.status.results['accuracy_score']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6e1828b8",
+   "metadata": {},
+   "source": [
+    "## 6. Compare Runtimes\n",
+    "\n",
+    "1. Delete the generated data.\n",
+    "2. Print a summary message.\n",
+    "3. Verify that the dask run took less time and yielded an accuracy score that is almost equal or better than the no dask run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "1420edeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the generated data:\n",
+    "shutil.rmtree(os.path.abspath(DATA_PATH))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "5fc153d9",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Without dask:\n",
+      "\t203.49 Seconds\n",
+      "\tAccuracy: 0.9708757575757576\n",
+      "With dask:\n",
+      "\t60.33 Seconds\n",
+      "\tAccuracy: 0.970410606060606\n",
+      "\n",
+      "Overall x3.37 faster!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print the test's collected results:\n",
+    "print(\n",
+    "    f\"Without dask:\\n\" \n",
+    "    f\"\\t{'%.2f' % without_dask_time} Seconds\\n\"\n",
+    "    f\"\\tAccuracy: {without_dask_score}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"With dask:\\n\"\n",
+    "    f\"\\t{'%.2f' % with_dask_time} Seconds\\n\"\n",
+    "    f\"\\tAccuracy: {with_dask_score}\\n\"\n",
+    ")\n",
+    "\n",
+    "# Verification:\n",
+    "assert with_dask_time < without_dask_time\n",
+    "assert np.isclose(without_dask_score, with_dask_score, atol=0.1)\n",
+    "\n",
+    "# Summary message:\n",
+    "print(f\"Overall x{'%.2f' % (without_dask_time / with_dask_time)} faster!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "809a6ff2",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test-dask-s3/test-dask-s3.ipynb
+++ b/test-dask-s3/test-dask-s3.ipynb
@@ -1,0 +1,1324 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e6198376",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "# Loading And Storing Data From And Into S3 With And Without Dask\n",
+    "\n",
+    "This test generates a big random data, uploading it to S3 and then processing it with and without Dask. Later it will verify that:\n",
+    "* The data was handled properly and results were equal.\n",
+    "* The stored dataset artifact in S3 is loadable and equal."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bc0cdf1a",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## General Configurations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "686b1e4a",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import sys\n",
+    "\n",
+    "sys.path.append(os.path.dirname(os.path.abspath(\"../\")))\n",
+    "\n",
+    "from utils import S3Client\n",
+    "\n",
+    "# AWS Credentials:\n",
+    "AWS_ACCESS_KEY_ID = os.environ.get(\"AWS_ACCESS_KEY_ID\", \"\")\n",
+    "AWS_SECRET_ACCESS_KEY = os.environ.get(\"AWS_SECRET_ACCESS_KEY\", \"\")\n",
+    "assert AWS_ACCESS_KEY_ID != \"\" and AWS_SECRET_ACCESS_KEY != \"\" \n",
+    "os.environ[\"AWS_ACCESS_KEY_ID\"] = AWS_ACCESS_KEY_ID\n",
+    "os.environ[\"AWS_SECRET_ACCESS_KEY\"] = AWS_SECRET_ACCESS_KEY\n",
+    "\n",
+    "# Path to store the generated data:\n",
+    "LOCAL_DATA_PATH = \"./data\"\n",
+    "S3_BUCKET = os.environ.get(\"S3_BUCKET\", \"testbucket-igz-temp\")\n",
+    "S3_PROJECT_DIRECTORY = \"test-dask-s3\"\n",
+    "S3_DATA_PATH = os.path.join(S3_PROJECT_DIRECTORY, \"data\")\n",
+    "\n",
+    "# Number of samples of generated data (number of rows in the data table):\n",
+    "N_SAMPLES = 2_000_000\n",
+    "\n",
+    "# Number of features of the generated data (number of columns in the data table):\n",
+    "N_FEATURES = 100\n",
+    "\n",
+    "# The amount of parquet partitions to have of the generated data:\n",
+    "N_PARTITIONS = 20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d22ad584",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## 1. Generate Data:\n",
+    "\n",
+    "1. Generate random data.\n",
+    "2. Turn the data into a `pandas.DataFrame` naming the columns `features_{i}` and adding the partioting column (year)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "aaf2c2d7",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "\n",
+    "def generate_data(\n",
+    "    output_path: str,\n",
+    "    n_samples: int, \n",
+    "    n_features: int, \n",
+    "    n_partitions: int,\n",
+    "):\n",
+    "    # Generate data:\n",
+    "    data = np.random.random(size=(n_samples, n_features))\n",
+    "    \n",
+    "    # Create a dataframe:\n",
+    "    data = pd.DataFrame(\n",
+    "        data=data, \n",
+    "        columns=[f\"feature_{i}\" for i in range(n_features)]\n",
+    "    )\n",
+    "    data[\"year\"] = np.random.randint(2000, 2000 + n_partitions, size=n_samples)\n",
+    "    \n",
+    "    # Save to parquets:\n",
+    "    data.to_parquet(output_path, partition_cols=[\"year\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "47bb49e6",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "Generate the data (will require writing permissions to the local directory and of course to S3)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "72db354c",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "31349eb17bce4ded868b96c09101b455",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Uploading:   0%|          | 0/20 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Uploading './data/year=2000/bb4627c3967b48aebd1c19efbd11e40b.parquet' to test-dask-s3/data/year=2000/bb4627c3967b48aebd1c19efbd11e40b.parquet\n",
+      "Uploading './data/year=2001/9ac7f5ce587249a39dd2fcf415025c60.parquet' to test-dask-s3/data/year=2001/9ac7f5ce587249a39dd2fcf415025c60.parquet\n",
+      "Uploading './data/year=2002/ede50f0d863841379ada5c7afce83e84.parquet' to test-dask-s3/data/year=2002/ede50f0d863841379ada5c7afce83e84.parquet\n",
+      "Uploading './data/year=2003/3600932d2ff04cc38036fac84279b467.parquet' to test-dask-s3/data/year=2003/3600932d2ff04cc38036fac84279b467.parquet\n",
+      "Uploading './data/year=2004/0f2df1a58b7746c492ceb5c55e8e2cc2.parquet' to test-dask-s3/data/year=2004/0f2df1a58b7746c492ceb5c55e8e2cc2.parquet\n",
+      "Uploading './data/year=2005/4bdff42d9d7249cc829e648217006463.parquet' to test-dask-s3/data/year=2005/4bdff42d9d7249cc829e648217006463.parquet\n",
+      "Uploading './data/year=2006/052509ff6e254055a64d3068de5d5c85.parquet' to test-dask-s3/data/year=2006/052509ff6e254055a64d3068de5d5c85.parquet\n",
+      "Uploading './data/year=2007/a6df52a9d3274dba810fb251a07d2b9c.parquet' to test-dask-s3/data/year=2007/a6df52a9d3274dba810fb251a07d2b9c.parquet\n",
+      "Uploading './data/year=2008/2e2ea6bcc0dc4847b3a1e550ed315fb7.parquet' to test-dask-s3/data/year=2008/2e2ea6bcc0dc4847b3a1e550ed315fb7.parquet\n",
+      "Uploading './data/year=2009/e6884c4305c5480eb385d46edce0d9fa.parquet' to test-dask-s3/data/year=2009/e6884c4305c5480eb385d46edce0d9fa.parquet\n",
+      "Uploading './data/year=2010/939a791c5cf34cefa6df3cfd83e06838.parquet' to test-dask-s3/data/year=2010/939a791c5cf34cefa6df3cfd83e06838.parquet\n",
+      "Uploading './data/year=2011/c307bf7d109e4a5f8f8ac84a245df151.parquet' to test-dask-s3/data/year=2011/c307bf7d109e4a5f8f8ac84a245df151.parquet\n",
+      "Uploading './data/year=2012/a642d49bba1a44ecb382f94c35d221b1.parquet' to test-dask-s3/data/year=2012/a642d49bba1a44ecb382f94c35d221b1.parquet\n",
+      "Uploading './data/year=2013/6dbb936431d14a77a38fc3586bbeaefb.parquet' to test-dask-s3/data/year=2013/6dbb936431d14a77a38fc3586bbeaefb.parquet\n",
+      "Uploading './data/year=2014/641de34dd8094fefb8425250c4ca09a1.parquet' to test-dask-s3/data/year=2014/641de34dd8094fefb8425250c4ca09a1.parquet\n",
+      "Uploading './data/year=2015/4768650b11f54652a5f77975c4877862.parquet' to test-dask-s3/data/year=2015/4768650b11f54652a5f77975c4877862.parquet\n",
+      "Uploading './data/year=2016/8020550feb8640d5ae724d0619285e2a.parquet' to test-dask-s3/data/year=2016/8020550feb8640d5ae724d0619285e2a.parquet\n",
+      "Uploading './data/year=2017/19d9adc6d83b4545b1a472b7c122b774.parquet' to test-dask-s3/data/year=2017/19d9adc6d83b4545b1a472b7c122b774.parquet\n",
+      "Uploading './data/year=2018/0b7b29c4a8fe4e298c2a6b47b8073d6c.parquet' to test-dask-s3/data/year=2018/0b7b29c4a8fe4e298c2a6b47b8073d6c.parquet\n",
+      "Uploading './data/year=2019/b1f3a2a111f54f048329e89fba79c51a.parquet' to test-dask-s3/data/year=2019/b1f3a2a111f54f048329e89fba79c51a.parquet\n",
+      "Done!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Delete past generated data (in case there was a failure):\n",
+    "if os.path.exists(LOCAL_DATA_PATH):\n",
+    "    shutil.rmtree(os.path.abspath(LOCAL_DATA_PATH))\n",
+    "\n",
+    "# Generate new data:\n",
+    "generate_data(\n",
+    "    output_path=LOCAL_DATA_PATH,\n",
+    "    n_samples=N_SAMPLES, \n",
+    "    n_features=N_FEATURES, \n",
+    "    n_partitions=N_PARTITIONS,\n",
+    ")\n",
+    "\n",
+    "# Upload it to S3:\n",
+    "s3_client = S3Client(\n",
+    "    aws_access_key_id=AWS_ACCESS_KEY_ID,\n",
+    "    aws_secret_access_key=AWS_SECRET_ACCESS_KEY,\n",
+    ")\n",
+    "s3_client.upload(\n",
+    "    bucket=S3_BUCKET,\n",
+    "    local_path=LOCAL_DATA_PATH,\n",
+    "    s3_path=S3_DATA_PATH,\n",
+    "    replace=False,\n",
+    ")\n",
+    "\n",
+    "# Delete new generated data (data will be loaded from S3):\n",
+    "shutil.rmtree(os.path.abspath(LOCAL_DATA_PATH))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "91de69dd",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## 2. Data Processing Code\n",
+    "\n",
+    "1. Read the data into a pandas (dask) `DataFrame` using MLRun's `DataItem.as_df`'s method.\n",
+    "2. Do some calculations.\n",
+    "\n",
+    "The calculations are accumulated into a single value that will be logged as a result along a single column of data (means in this case) to be stored in S3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f04bd556",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# mlrun: start-code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "30f83479",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import dask\n",
+    "import mlrun\n",
+    "\n",
+    "\n",
+    "@mlrun.handler(outputs=[\"result\", \"means\"])\n",
+    "def process_data(context: mlrun.MLClientCtx, data_path: mlrun.DataItem):\n",
+    "    # Check for a dask client:\n",
+    "    dask_function = context.get_param(\"dask_function\", None)\n",
+    "    dask_client = mlrun.import_function(dask_function).client if dask_function else None\n",
+    "    \n",
+    "    # Get the data:\n",
+    "    data = data_path.as_df(\n",
+    "        df_module=dask.dataframe if dask_client else pd,\n",
+    "        format=\"parquet\"\n",
+    "    )\n",
+    "    \n",
+    "    # Do some random calculations:\n",
+    "    if dask_client:\n",
+    "        data = dask_client.persist(data)\n",
+    "    sum_value = data.sum()\n",
+    "    mean_value = data.mean()\n",
+    "    var_value = data.var()\n",
+    "    if dask_client:\n",
+    "        sum_value = dask.delayed(sum)(sum_value)\n",
+    "        mean_value = dask.delayed(sum)(mean_value)\n",
+    "        var_value = dask.delayed(sum)(var_value)\n",
+    "    else:\n",
+    "        sum_value = sum(sum_value)\n",
+    "        mean_value = sum(mean_value)\n",
+    "        var_value = sum(var_value)\n",
+    "    result = sum_value + mean_value + var_value\n",
+    "    means = data.mean()\n",
+    "    for column in data.columns:\n",
+    "        means = means + means * means\n",
+    "    if dask_client:\n",
+    "        result = result.compute()\n",
+    "        means = means.compute()\n",
+    "    \n",
+    "    # Log the values:\n",
+    "    return result, means"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "88a461ee",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# mlrun: end-code"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1244c341",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## 3. Create a Project\n",
+    "\n",
+    "1. Create the MLRun project.\n",
+    "2. Use MLRun's `code_to_function` to create an MLRun function of the processing code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6d5ca866",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import shutil\n",
+    "import time\n",
+    "\n",
+    "import mlrun"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "99478829",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:03:52,095 [info] loaded project test-dask-s3 from MLRun DB\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Create the project:\n",
+    "project = mlrun.get_or_create_project(\n",
+    "    name=S3_PROJECT_DIRECTORY, \n",
+    "    context=\"./\",\n",
+    "    user_project=False\n",
+    ")\n",
+    "\n",
+    "# Add the S3 credentials:\n",
+    "project.set_secrets(\n",
+    "    secrets={\n",
+    "        \"AWS_ACCESS_KEY_ID\": AWS_ACCESS_KEY_ID,\n",
+    "        \"AWS_SECRET_ACCESS_KEY\": AWS_SECRET_ACCESS_KEY,\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "0519ade5",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<mlrun.runtimes.kubejob.KubejobRuntime at 0x7efd66c31550>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create the training function:\n",
+    "process_data_function = mlrun.code_to_function(\n",
+    "    name=\"process_data\",\n",
+    "    kind=\"job\",\n",
+    "    image=\"mlrun/mlrun\",\n",
+    "    handler=\"process_data\",\n",
+    ")\n",
+    "\n",
+    "# Assign the function to the project:\n",
+    "project.set_function(process_data_function)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56749cff",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## 4. Run Without Dask\n",
+    "\n",
+    "Run the processing without Dask while timing it and storing the result score and means."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "c80148d6",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:03:59,049 [info] starting run without_dask uid=66ffa9e041f1477ca2fe42d44aef9bca DB=http://mlrun-api:8080\n",
+      "> 2022-12-18 11:03:59,260 [info] Job is running in the background, pod: without-dask-28lzr\n",
+      "> 2022-12-18 11:17:47,839 [info] To track results use the CLI: {'info_cmd': 'mlrun get run 66ffa9e041f1477ca2fe42d44aef9bca -p test-dask-s3', 'logs_cmd': 'mlrun logs 66ffa9e041f1477ca2fe42d44aef9bca -p test-dask-s3'}\n",
+      "> 2022-12-18 11:17:47,840 [info] Or click for UI: {'ui_url': 'https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/test-dask-s3/jobs/monitor/66ffa9e041f1477ca2fe42d44aef9bca/overview'}\n",
+      "> 2022-12-18 11:17:47,840 [info] run executed, status=completed\n",
+      "invalid value encountered in subtract\n",
+      "final state: completed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".dictlist {\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: center;\n",
+       "  margin: 4px;\n",
+       "  border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}\n",
+       ".artifact {\n",
+       "  cursor: pointer;\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: left;\n",
+       "  margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;\n",
+       "}\n",
+       "div.block.hidden {\n",
+       "  display: none;\n",
+       "}\n",
+       ".clickable {\n",
+       "  cursor: pointer;\n",
+       "}\n",
+       ".ellipsis {\n",
+       "  display: inline-block;\n",
+       "  max-width: 60px;\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "}\n",
+       ".master-wrapper {\n",
+       "  display: flex;\n",
+       "  flex-flow: row nowrap;\n",
+       "  justify-content: flex-start;\n",
+       "  align-items: stretch;\n",
+       "}\n",
+       ".master-tbl {\n",
+       "  flex: 3\n",
+       "}\n",
+       ".master-wrapper > div {\n",
+       "  margin: 4px;\n",
+       "  padding: 10px;\n",
+       "}\n",
+       "iframe.fileview {\n",
+       "  border: 0 none;\n",
+       "  height: 100%;\n",
+       "  width: 100%;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       ".pane-header-title {\n",
+       "  width: 80%;\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       ".pane-header {\n",
+       "  line-height: 1;\n",
+       "  background-color: #4EC64B;\n",
+       "  padding: 3px;\n",
+       "}\n",
+       ".pane-header .close {\n",
+       "  font-size: 20px;\n",
+       "  font-weight: 700;\n",
+       "  float: right;\n",
+       "  margin-top: -5px;\n",
+       "}\n",
+       ".master-wrapper .right-pane {\n",
+       "  border: 1px inset silver;\n",
+       "  width: 40%;\n",
+       "  min-height: 300px;\n",
+       "  flex: 3\n",
+       "  min-width: 500px;\n",
+       "}\n",
+       ".master-wrapper * {\n",
+       "  box-sizing: border-box;\n",
+       "}\n",
+       "</style><script>\n",
+       "function copyToClipboard(fld) {\n",
+       "    if (document.queryCommandSupported && document.queryCommandSupported('copy')) {\n",
+       "        var textarea = document.createElement('textarea');\n",
+       "        textarea.textContent = fld.innerHTML;\n",
+       "        textarea.style.position = 'fixed';\n",
+       "        document.body.appendChild(textarea);\n",
+       "        textarea.select();\n",
+       "\n",
+       "        try {\n",
+       "            return document.execCommand('copy'); // Security exception may be thrown by some browsers.\n",
+       "        } catch (ex) {\n",
+       "\n",
+       "        } finally {\n",
+       "            document.body.removeChild(textarea);\n",
+       "        }\n",
+       "    }\n",
+       "}\n",
+       "function expandPanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName');\n",
+       "  console.log(el.title);\n",
+       "\n",
+       "  document.querySelector(panelName + \"-title\").innerHTML = el.title\n",
+       "  iframe = document.querySelector(panelName + \"-body\");\n",
+       "\n",
+       "  const tblcss = `<style> body { font-family: Arial, Helvetica, sans-serif;}\n",
+       "    #csv { margin-bottom: 15px; }\n",
+       "    #csv table { border-collapse: collapse;}\n",
+       "    #csv table td { padding: 4px 8px; border: 1px solid silver;} </style>`;\n",
+       "\n",
+       "  function csvToHtmlTable(str) {\n",
+       "    return '<div id=\"csv\"><table><tr><td>' +  str.replace(/[\\n\\r]+$/g, '').replace(/[\\n\\r]+/g, '</td></tr><tr><td>')\n",
+       "      .replace(/,/g, '</td><td>') + '</td></tr></table></div>';\n",
+       "  }\n",
+       "\n",
+       "  function reqListener () {\n",
+       "    if (el.title.endsWith(\".csv\")) {\n",
+       "      iframe.setAttribute(\"srcdoc\", tblcss + csvToHtmlTable(this.responseText));\n",
+       "    } else {\n",
+       "      iframe.setAttribute(\"srcdoc\", this.responseText);\n",
+       "    }\n",
+       "    console.log(this.responseText);\n",
+       "  }\n",
+       "\n",
+       "  const oReq = new XMLHttpRequest();\n",
+       "  oReq.addEventListener(\"load\", reqListener);\n",
+       "  oReq.open(\"GET\", el.title);\n",
+       "  oReq.send();\n",
+       "\n",
+       "\n",
+       "  //iframe.src = el.title;\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.remove(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "function closePanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName')\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (!resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.add(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "\n",
+       "</script>\n",
+       "<div class=\"master-wrapper\">\n",
+       "  <div class=\"block master-tbl\"><div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>project</th>\n",
+       "      <th>uid</th>\n",
+       "      <th>iter</th>\n",
+       "      <th>start</th>\n",
+       "      <th>state</th>\n",
+       "      <th>name</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>inputs</th>\n",
+       "      <th>parameters</th>\n",
+       "      <th>results</th>\n",
+       "      <th>artifacts</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>test-dask-s3</td>\n",
+       "      <td><div title=\"66ffa9e041f1477ca2fe42d44aef9bca\"><a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/test-dask-s3/jobs/monitor/66ffa9e041f1477ca2fe42d44aef9bca/overview\" target=\"_blank\" >...4aef9bca</a></div></td>\n",
+       "      <td>0</td>\n",
+       "      <td>Dec 18 11:04:04</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>without_dask</td>\n",
+       "      <td><div class=\"dictlist\">v3io_user=guyl</div><div class=\"dictlist\">kind=job</div><div class=\"dictlist\">owner=guyl</div><div class=\"dictlist\">mlrun/client_version=1.2.1-rc4</div><div class=\"dictlist\">host=without-dask-28lzr</div></td>\n",
+       "      <td><div title=\"s3://testbucket-igz-temp/test-dask-s3/data/\">data_path</div></td>\n",
+       "      <td><div class=\"dictlist\">dask_function=None</div></td>\n",
+       "      <td><div class=\"dictlist\">result=100004548.27844404</div></td>\n",
+       "      <td><div title=\"s3://testbucket-igz-temp/test-dask-s3/without_dask/0/means.parquet\">means</div></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div></div>\n",
+       "  <div id=\"resultd023b996-pane\" class=\"right-pane block hidden\">\n",
+       "    <div class=\"pane-header\">\n",
+       "      <span id=\"resultd023b996-title\" class=\"pane-header-title\">Title</span>\n",
+       "      <span onclick=\"closePanel(this)\" paneName=\"resultd023b996\" class=\"close clickable\">&times;</span>\n",
+       "    </div>\n",
+       "    <iframe class=\"fileview\" id=\"resultd023b996-body\"></iframe>\n",
+       "  </div>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<b> > to track results use the .show() or .logs() methods  or <a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/test-dask-s3/jobs/monitor/66ffa9e041f1477ca2fe42d44aef9bca/overview\" target=\"_blank\">click here</a> to open in UI</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:17:48,151 [info] run executed, status=completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "without_dask_time = time.time()\n",
+    "without_dask_run = process_data_function.run(\n",
+    "    name=\"without_dask\",\n",
+    "    inputs={\n",
+    "        \"data_path\": f\"s3://{S3_BUCKET}/{S3_PROJECT_DIRECTORY}/data/\",\n",
+    "    },\n",
+    "    artifact_path=f\"s3://{S3_BUCKET}/{S3_PROJECT_DIRECTORY}\",\n",
+    ")\n",
+    "without_dask_time = time.time() - without_dask_time\n",
+    "without_dask_result = without_dask_run.status.results['result']\n",
+    "without_dask_means = np.array(without_dask_run.artifact('means').as_df()[\"0\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc641516",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## 5. Run With Dask\n",
+    "\n",
+    "1. Create the Dask function.\n",
+    "2. Configure it.\n",
+    "3. Run the data processing with Dask while timing it and storing the result and means."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "cb8b49be",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'db://test-dask-s3/my-dask'"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Create the dask function:\n",
+    "dask_function = mlrun.new_function(name=\"my_dask\", kind=\"dask\", image=\"mlrun/mlrun\")\n",
+    "\n",
+    "# Configure the dask function specs:\n",
+    "dask_function.spec.remote = True\n",
+    "dask_function.spec.replicas = 5\n",
+    "dask_function.spec.service_type = 'NodePort'\n",
+    "dask_function.with_limits(mem=\"6G\")\n",
+    "dask_function.spec.nthreads = 5\n",
+    "\n",
+    "# Assign the function to the project:\n",
+    "project.set_function(dask_function)\n",
+    "\n",
+    "# Save:\n",
+    "dask_function.save()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2daf6c76",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:18:01,379 [info] trying dask client at: tcp://mlrun-my-dask-f4f760b7-d.default-tenant:8786\n",
+      "> 2022-12-18 11:18:01,423 [info] using remote dask scheduler (mlrun-my-dask-f4f760b7-d) at: tcp://mlrun-my-dask-f4f760b7-d.default-tenant:8786\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Mismatched versions found\n",
+      "\n",
+      "+-------------+--------+-----------+---------+\n",
+      "| Package     | client | scheduler | workers |\n",
+      "+-------------+--------+-----------+---------+\n",
+      "| blosc       | 1.7.0  | None      | None    |\n",
+      "| cloudpickle | 2.0.0  | 2.2.0     | None    |\n",
+      "| lz4         | 3.1.0  | None      | None    |\n",
+      "| msgpack     | 1.0.3  | 1.0.4     | None    |\n",
+      "| toolz       | 0.11.2 | 0.12.0    | None    |\n",
+      "| tornado     | 6.1    | 6.2       | None    |\n",
+      "+-------------+--------+-----------+---------+\n",
+      "Notes: \n",
+      "-  msgpack: Variation is ok, as long as everything is above 0.6\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<a href=\"http://default-tenant.app.dev6.lab.iguazeng.com:31276/status\" target=\"_blank\" >dashboard link: default-tenant.app.dev6.lab.iguazeng.com:31276</a>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "    <div style=\"width: 24px; height: 24px; background-color: #e1e1e1; border: 3px solid #9D9D9D; border-radius: 5px; position: absolute;\"> </div>\n",
+       "    <div style=\"margin-left: 48px;\">\n",
+       "        <h3 style=\"margin-bottom: 0px;\">Client</h3>\n",
+       "        <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Client-a23fe1be-7ec5-11ed-a34d-4dff94150cb0</p>\n",
+       "        <table style=\"width: 100%; text-align: left;\">\n",
+       "\n",
+       "        <tr>\n",
+       "        \n",
+       "            <td style=\"text-align: left;\"><strong>Connection method:</strong> Direct</td>\n",
+       "            <td style=\"text-align: left;\"></td>\n",
+       "        \n",
+       "        </tr>\n",
+       "\n",
+       "        \n",
+       "            <tr>\n",
+       "                <td style=\"text-align: left;\">\n",
+       "                    <strong>Dashboard: </strong> <a href=\"http://mlrun-my-dask-f4f760b7-d.default-tenant:8787/status\" target=\"_blank\">http://mlrun-my-dask-f4f760b7-d.default-tenant:8787/status</a>\n",
+       "                </td>\n",
+       "                <td style=\"text-align: left;\"></td>\n",
+       "            </tr>\n",
+       "        \n",
+       "\n",
+       "        </table>\n",
+       "\n",
+       "        \n",
+       "            <details>\n",
+       "            <summary style=\"margin-bottom: 20px;\"><h3 style=\"display: inline;\">Scheduler Info</h3></summary>\n",
+       "            <div style=\"\">\n",
+       "    <div>\n",
+       "        <div style=\"width: 24px; height: 24px; background-color: #FFF7E5; border: 3px solid #FF6132; border-radius: 5px; position: absolute;\"> </div>\n",
+       "        <div style=\"margin-left: 48px;\">\n",
+       "            <h3 style=\"margin-bottom: 0px;\">Scheduler</h3>\n",
+       "            <p style=\"color: #9D9D9D; margin-bottom: 0px;\">Scheduler-ac08cb37-ec5b-4364-8cd3-2f15e5644c39</p>\n",
+       "            <table style=\"width: 100%; text-align: left;\">\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Comm:</strong> tcp://10.201.103.45:8786\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Workers:</strong> 0\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Dashboard:</strong> <a href=\"http://10.201.103.45:8787/status\" target=\"_blank\">http://10.201.103.45:8787/status</a>\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total threads:</strong> 0\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "                <tr>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Started:</strong> Just now\n",
+       "                    </td>\n",
+       "                    <td style=\"text-align: left;\">\n",
+       "                        <strong>Total memory:</strong> 0 B\n",
+       "                    </td>\n",
+       "                </tr>\n",
+       "            </table>\n",
+       "        </div>\n",
+       "    </div>\n",
+       "\n",
+       "    <details style=\"margin-left: 48px;\">\n",
+       "        <summary style=\"margin-bottom: 20px;\">\n",
+       "            <h3 style=\"display: inline;\">Workers</h3>\n",
+       "        </summary>\n",
+       "\n",
+       "        \n",
+       "\n",
+       "    </details>\n",
+       "</div>\n",
+       "            </details>\n",
+       "        \n",
+       "\n",
+       "    </div>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "<Client: 'tcp://10.201.103.45:8786' processes=0 threads=0, memory=0 B>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dask_function.client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "1c7b8918",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:18:01,478 [info] starting run with_dask uid=0ac62c65edbd4973b54472fddd908052 DB=http://mlrun-api:8080\n",
+      "> 2022-12-18 11:18:01,665 [info] Job is running in the background, pod: with-dask-l5cvp\n",
+      "> 2022-12-18 11:18:08,486 [info] trying dask client at: tcp://mlrun-my-dask-f4f760b7-d.default-tenant:8786\n",
+      "> 2022-12-18 11:18:08,497 [info] using remote dask scheduler (mlrun-my-dask-f4f760b7-d) at: tcp://mlrun-my-dask-f4f760b7-d.default-tenant:8786\n",
+      "remote dashboard: default-tenant.app.dev6.lab.iguazeng.com:31276\n",
+      "> 2022-12-18 11:22:45,040 [info] To track results use the CLI: {'info_cmd': 'mlrun get run 0ac62c65edbd4973b54472fddd908052 -p test-dask-s3', 'logs_cmd': 'mlrun logs 0ac62c65edbd4973b54472fddd908052 -p test-dask-s3'}\n",
+      "> 2022-12-18 11:22:45,040 [info] Or click for UI: {'ui_url': 'https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/test-dask-s3/jobs/monitor/0ac62c65edbd4973b54472fddd908052/overview'}\n",
+      "> 2022-12-18 11:22:45,041 [info] run executed, status=completed\n",
+      "invalid value encountered in subtract\n",
+      "final state: completed\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<style>\n",
+       ".dictlist {\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: center;\n",
+       "  margin: 4px;\n",
+       "  border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;}\n",
+       ".artifact {\n",
+       "  cursor: pointer;\n",
+       "  background-color: #4EC64B;\n",
+       "  text-align: left;\n",
+       "  margin: 4px; border-radius: 3px; padding: 0px 3px 1px 3px; display: inline-block;\n",
+       "}\n",
+       "div.block.hidden {\n",
+       "  display: none;\n",
+       "}\n",
+       ".clickable {\n",
+       "  cursor: pointer;\n",
+       "}\n",
+       ".ellipsis {\n",
+       "  display: inline-block;\n",
+       "  max-width: 60px;\n",
+       "  white-space: nowrap;\n",
+       "  overflow: hidden;\n",
+       "  text-overflow: ellipsis;\n",
+       "}\n",
+       ".master-wrapper {\n",
+       "  display: flex;\n",
+       "  flex-flow: row nowrap;\n",
+       "  justify-content: flex-start;\n",
+       "  align-items: stretch;\n",
+       "}\n",
+       ".master-tbl {\n",
+       "  flex: 3\n",
+       "}\n",
+       ".master-wrapper > div {\n",
+       "  margin: 4px;\n",
+       "  padding: 10px;\n",
+       "}\n",
+       "iframe.fileview {\n",
+       "  border: 0 none;\n",
+       "  height: 100%;\n",
+       "  width: 100%;\n",
+       "  white-space: pre-wrap;\n",
+       "}\n",
+       ".pane-header-title {\n",
+       "  width: 80%;\n",
+       "  font-weight: 500;\n",
+       "}\n",
+       ".pane-header {\n",
+       "  line-height: 1;\n",
+       "  background-color: #4EC64B;\n",
+       "  padding: 3px;\n",
+       "}\n",
+       ".pane-header .close {\n",
+       "  font-size: 20px;\n",
+       "  font-weight: 700;\n",
+       "  float: right;\n",
+       "  margin-top: -5px;\n",
+       "}\n",
+       ".master-wrapper .right-pane {\n",
+       "  border: 1px inset silver;\n",
+       "  width: 40%;\n",
+       "  min-height: 300px;\n",
+       "  flex: 3\n",
+       "  min-width: 500px;\n",
+       "}\n",
+       ".master-wrapper * {\n",
+       "  box-sizing: border-box;\n",
+       "}\n",
+       "</style><script>\n",
+       "function copyToClipboard(fld) {\n",
+       "    if (document.queryCommandSupported && document.queryCommandSupported('copy')) {\n",
+       "        var textarea = document.createElement('textarea');\n",
+       "        textarea.textContent = fld.innerHTML;\n",
+       "        textarea.style.position = 'fixed';\n",
+       "        document.body.appendChild(textarea);\n",
+       "        textarea.select();\n",
+       "\n",
+       "        try {\n",
+       "            return document.execCommand('copy'); // Security exception may be thrown by some browsers.\n",
+       "        } catch (ex) {\n",
+       "\n",
+       "        } finally {\n",
+       "            document.body.removeChild(textarea);\n",
+       "        }\n",
+       "    }\n",
+       "}\n",
+       "function expandPanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName');\n",
+       "  console.log(el.title);\n",
+       "\n",
+       "  document.querySelector(panelName + \"-title\").innerHTML = el.title\n",
+       "  iframe = document.querySelector(panelName + \"-body\");\n",
+       "\n",
+       "  const tblcss = `<style> body { font-family: Arial, Helvetica, sans-serif;}\n",
+       "    #csv { margin-bottom: 15px; }\n",
+       "    #csv table { border-collapse: collapse;}\n",
+       "    #csv table td { padding: 4px 8px; border: 1px solid silver;} </style>`;\n",
+       "\n",
+       "  function csvToHtmlTable(str) {\n",
+       "    return '<div id=\"csv\"><table><tr><td>' +  str.replace(/[\\n\\r]+$/g, '').replace(/[\\n\\r]+/g, '</td></tr><tr><td>')\n",
+       "      .replace(/,/g, '</td><td>') + '</td></tr></table></div>';\n",
+       "  }\n",
+       "\n",
+       "  function reqListener () {\n",
+       "    if (el.title.endsWith(\".csv\")) {\n",
+       "      iframe.setAttribute(\"srcdoc\", tblcss + csvToHtmlTable(this.responseText));\n",
+       "    } else {\n",
+       "      iframe.setAttribute(\"srcdoc\", this.responseText);\n",
+       "    }\n",
+       "    console.log(this.responseText);\n",
+       "  }\n",
+       "\n",
+       "  const oReq = new XMLHttpRequest();\n",
+       "  oReq.addEventListener(\"load\", reqListener);\n",
+       "  oReq.open(\"GET\", el.title);\n",
+       "  oReq.send();\n",
+       "\n",
+       "\n",
+       "  //iframe.src = el.title;\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.remove(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "function closePanel(el) {\n",
+       "  const panelName = \"#\" + el.getAttribute('paneName')\n",
+       "  const resultPane = document.querySelector(panelName + \"-pane\");\n",
+       "  if (!resultPane.classList.contains(\"hidden\")) {\n",
+       "    resultPane.classList.add(\"hidden\");\n",
+       "  }\n",
+       "}\n",
+       "\n",
+       "</script>\n",
+       "<div class=\"master-wrapper\">\n",
+       "  <div class=\"block master-tbl\"><div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th>project</th>\n",
+       "      <th>uid</th>\n",
+       "      <th>iter</th>\n",
+       "      <th>start</th>\n",
+       "      <th>state</th>\n",
+       "      <th>name</th>\n",
+       "      <th>labels</th>\n",
+       "      <th>inputs</th>\n",
+       "      <th>parameters</th>\n",
+       "      <th>results</th>\n",
+       "      <th>artifacts</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>test-dask-s3</td>\n",
+       "      <td><div title=\"0ac62c65edbd4973b54472fddd908052\"><a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/test-dask-s3/jobs/monitor/0ac62c65edbd4973b54472fddd908052/overview\" target=\"_blank\" >...dd908052</a></div></td>\n",
+       "      <td>0</td>\n",
+       "      <td>Dec 18 11:18:06</td>\n",
+       "      <td>completed</td>\n",
+       "      <td>with_dask</td>\n",
+       "      <td><div class=\"dictlist\">v3io_user=guyl</div><div class=\"dictlist\">kind=job</div><div class=\"dictlist\">owner=guyl</div><div class=\"dictlist\">mlrun/client_version=1.2.1-rc4</div><div class=\"dictlist\">host=with-dask-l5cvp</div></td>\n",
+       "      <td><div title=\"s3://testbucket-igz-temp/test-dask-s3/data/\">data_path</div></td>\n",
+       "      <td><div class=\"dictlist\">dask_function=db://test-dask-s3/my-dask</div></td>\n",
+       "      <td><div class=\"dictlist\">result=100004548.27844404</div></td>\n",
+       "      <td><div title=\"s3://testbucket-igz-temp/test-dask-s3/with_dask/0/means.parquet\">means</div></td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div></div>\n",
+       "  <div id=\"resulta82cc953-pane\" class=\"right-pane block hidden\">\n",
+       "    <div class=\"pane-header\">\n",
+       "      <span id=\"resulta82cc953-title\" class=\"pane-header-title\">Title</span>\n",
+       "      <span onclick=\"closePanel(this)\" paneName=\"resulta82cc953\" class=\"close clickable\">&times;</span>\n",
+       "    </div>\n",
+       "    <iframe class=\"fileview\" id=\"resulta82cc953-body\"></iframe>\n",
+       "  </div>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<b> > to track results use the .show() or .logs() methods  or <a href=\"https://dashboard.default-tenant.app.dev6.lab.iguazeng.com/mlprojects/test-dask-s3/jobs/monitor/0ac62c65edbd4973b54472fddd908052/overview\" target=\"_blank\">click here</a> to open in UI</b>"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> 2022-12-18 11:22:53,567 [info] run executed, status=completed\n"
+     ]
+    }
+   ],
+   "source": [
+    "with_dask_time = time.time()\n",
+    "with_dask_run = process_data_function.run(\n",
+    "    name=\"with_dask\",\n",
+    "    inputs={\n",
+    "        \"data_path\": f\"s3://{S3_BUCKET}/{S3_PROJECT_DIRECTORY}/data/\",\n",
+    "    },\n",
+    "    params={\n",
+    "        \"dask_function\": \"db://\" + dask_function.uri,\n",
+    "    },\n",
+    "    artifact_path=f\"s3://{S3_BUCKET}/{S3_PROJECT_DIRECTORY}\",\n",
+    ")\n",
+    "with_dask_time = time.time() - with_dask_time\n",
+    "with_dask_result = with_dask_run.status.results['result']\n",
+    "with_dask_means = np.array(with_dask_run.artifact('means').as_df()[\"0\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1991ffbc",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "## 6. Compare Runtimes\n",
+    "\n",
+    "1. Print a summary message.\n",
+    "2. Verify that the dask run took less time and yielded an accuracy score that is almost equal or better than the no dask run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "f6d7dda9",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "7781be22a184443d8e47dd0baa85b1bb",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Deleting:   0%|          | 0/22 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Deleting 'test-dask-s3/data/year=2000/bb4627c3967b48aebd1c19efbd11e40b.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2001/9ac7f5ce587249a39dd2fcf415025c60.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2002/ede50f0d863841379ada5c7afce83e84.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2003/3600932d2ff04cc38036fac84279b467.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2004/0f2df1a58b7746c492ceb5c55e8e2cc2.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2005/4bdff42d9d7249cc829e648217006463.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2006/052509ff6e254055a64d3068de5d5c85.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2007/a6df52a9d3274dba810fb251a07d2b9c.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2008/2e2ea6bcc0dc4847b3a1e550ed315fb7.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2009/e6884c4305c5480eb385d46edce0d9fa.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2010/939a791c5cf34cefa6df3cfd83e06838.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2011/c307bf7d109e4a5f8f8ac84a245df151.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2012/a642d49bba1a44ecb382f94c35d221b1.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2013/6dbb936431d14a77a38fc3586bbeaefb.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2014/641de34dd8094fefb8425250c4ca09a1.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2015/4768650b11f54652a5f77975c4877862.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2016/8020550feb8640d5ae724d0619285e2a.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2017/19d9adc6d83b4545b1a472b7c122b774.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2018/0b7b29c4a8fe4e298c2a6b47b8073d6c.parquet'\n",
+      "Deleting 'test-dask-s3/data/year=2019/b1f3a2a111f54f048329e89fba79c51a.parquet'\n",
+      "Deleting 'test-dask-s3/with_dask/0/means.parquet'\n",
+      "Deleting 'test-dask-s3/without_dask/0/means.parquet'\n",
+      "Done!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Delete the project and data in S3:\n",
+    "s3_client.delete(\n",
+    "    bucket=S3_BUCKET,\n",
+    "    s3_path=S3_PROJECT_DIRECTORY,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "418f67b2",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Without dask:\n",
+      "\t829.11 Seconds\n",
+      "\tResult: 100004548.27844404\n",
+      "With dask:\n",
+      "\t292.09 Seconds\n",
+      "\tResult: 100004548.27844404\n",
+      "\n",
+      "Overall x2.84 faster!\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Print the test's collected results:\n",
+    "print(\n",
+    "    f\"Without dask:\\n\" \n",
+    "    f\"\\t{'%.2f' % without_dask_time} Seconds\\n\"\n",
+    "    f\"\\tResult: {without_dask_result}\"\n",
+    ")\n",
+    "print(\n",
+    "    f\"With dask:\\n\"\n",
+    "    f\"\\t{'%.2f' % with_dask_time} Seconds\\n\"\n",
+    "    f\"\\tResult: {with_dask_result}\\n\"\n",
+    ")\n",
+    "\n",
+    "# Verification:\n",
+    "assert with_dask_time < without_dask_time\n",
+    "assert np.isclose(without_dask_result, with_dask_result)\n",
+    "assert np.allclose(without_dask_means, with_dask_means)\n",
+    "\n",
+    "# Summary message:\n",
+    "print(f\"Overall x{'%.2f' % (without_dask_time / with_dask_time)} faster!\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d0174be2",
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+from .s3_client import S3Client

--- a/utils/s3_client.py
+++ b/utils/s3_client.py
@@ -1,0 +1,389 @@
+from typing import List
+import os
+import glob
+import warnings
+
+import boto3
+
+# Import tqdm progressbar according to the running environment (jupyter or cli):
+try:
+    from IPython import get_ipython
+
+    SHELL = get_ipython().__class__.__name__
+    if SHELL == "ZMQInteractiveShell":
+        from tqdm.notebook import tqdm
+    else:
+        SHELL = None
+        from tqdm import tqdm
+except ModuleNotFoundError:
+    SHELL = None
+    from tqdm import tqdm
+
+
+class S3Client:
+    """
+    An easy to use S3 client for uploading, downloading and deleting single files or directories.
+
+    S3 do not have actual directories. Each file's name is a key, but if the key has a seperator '/' in it the UI in S3
+    shows it as a directory. This client handles these kind of directories.
+    """
+
+    def __init__(
+        self,
+        aws_access_key_id: str = None,
+        aws_secret_access_key: str = None,
+    ):
+        """
+        Initialize a S3 client object (not opening a session yet) with the given credentials.
+
+        :param aws_access_key_id:     The AWS access key id.
+        :param aws_secret_access_key: The AWS secret access key.
+        """
+        self._aws_access_key_id = aws_access_key_id
+        self._aws_secret_access_key = aws_secret_access_key
+
+    def upload(
+        self,
+        bucket: str,
+        local_path: str,
+        s3_path: str,
+        replace: bool = True,
+        verbose: bool = True,
+    ):
+        """
+        Upload a given file or directory to S3.
+
+        Please notice to not put a '/' prefix in the `s3_path` as S3 will interpreate the '/' as a directory named '/'.
+
+        :param bucket:     The bucket to upload to.
+        :param local_path: The path to the local file or directory to upload.
+        :param s3_path:    The path to upload to in the S3 bucket.
+        :param replace:    Whether to replace the files when uploading or skip if they already exist. Default: True.
+        :param verbose:    Whether to log uploading information. Default: True.
+
+        :raise ValueError: If the given local path do not exist, or it is a path of an empty directory.
+
+        Example:
+            >>> s3_client = S3Client()
+            >>> s3_client.upload(
+            ...     bucket="my_bucket",
+            ...     local_path="/path/to/a/local/directory",
+            ...     s3_path="path/to/a/s3/directory",
+            ...     replace=False,
+            ... )
+        """
+        # Initialize a S3 client:
+        s3 = self._init_client()
+
+        # Check if the given S3 path is starting with a '/':
+        if s3_path[0] == "/":
+            warnings.warn(
+                f"Uploading to S3 with a path starting with a '/' is not recommended. Given S3 path: '{s3_path}'. "
+                f"S3 do not have directories, the UI simply parse separators ('/') in the files keys as directories. "
+                f"Hence, putting a '/' at the beginning of the path will create a directory named '/'."
+            )
+
+        # Check if path exist:
+        if not os.path.exists(local_path):
+            raise ValueError(f"The given local path '{local_path}' do not exist")
+
+        # Check if it's a single file or directory:
+        if os.path.isfile(local_path):
+            self._upload_file(
+                s3_client=s3,
+                local_path=local_path,
+                s3_path=s3_path,
+                bucket=bucket,
+                replace=replace,
+                verbose=verbose,
+            )
+        else:
+            self._upload_directory(
+                s3_client=s3,
+                local_path=local_path,
+                s3_path=s3_path,
+                bucket=bucket,
+                replace=replace,
+                verbose=verbose,
+            )
+        if verbose:
+            print("Done!")
+
+    def download(
+        self,
+        bucket: str,
+        local_path: str,
+        s3_path: str,
+        replace: bool = True,
+        verbose: bool = True,
+    ):
+        """
+        Download a given file or directory from S3.
+
+        :param bucket:     The bucket to download from.
+        :param local_path: The path to the local file or directory to download to.
+        :param s3_path:    The path to the file or directory to download in the S3 bucket.
+        :param replace:    Whether to replace the files when downloading or skip if they already exist. Default: True.
+        :param verbose:    Whether to log downloading information. Default: True.
+
+        :raise FileNotFoundError: If the given S3 path do not exist.
+
+        Example:
+            >>> s3_client = S3Client()
+            >>> s3_client.download(
+            ...     bucket="my_bucket",
+            ...     local_path="/path/to/a/local/directory",
+            ...     s3_path="path/to/a/s3/directory",
+            ...     replace=False,
+            ... )
+        """
+        # Initialize a S3 client:
+        s3 = self._init_client()
+
+        # Look for all files beginning with the given key (`s3_path`):
+        files = self._get_files(s3_client=s3, s3_path=s3_path, bucket=bucket)
+
+        # If the list is empty, there is no such file:
+        if len(files) == 0:
+            raise FileNotFoundError(
+                f"There is no file at the bucket '{bucket}' named '{s3_path}'."
+            )
+
+        # Check if it's a single file or directory:
+        if len(files) == 1:
+            self._download_file(
+                s3_client=s3,
+                local_path=local_path,
+                s3_path=s3_path,
+                bucket=bucket,
+                replace=replace,
+                verbose=verbose,
+            )
+        else:
+            self._download_directory(
+                s3_client=s3,
+                local_path=local_path,
+                s3_directory_path=s3_path,
+                s3_files_paths=files,
+                bucket=bucket,
+                replace=replace,
+                verbose=verbose,
+            )
+        if verbose:
+            print("Done!")
+
+    def delete(self, bucket: str, s3_path: str, verbose: bool = True):
+        """
+        Delete a given file or directory from S3.
+
+        A file is deleted only if the file is not versioned, otherwise this function will just mark it as deleted in its
+        latest version.
+
+        :param bucket:  The bucket to delete from.
+        :param s3_path: The path to the file or directory to delete in the S3 bucket.
+        :param verbose: Whether to log deletion information. Default: True.
+
+        :raise FileNotFoundError: If the given S3 path do not exist.
+
+        Example:
+            >>> s3_client = S3Client()
+            >>> s3_client.delete(
+            ...     bucket="my_bucket",
+            ...     s3_path="path/to/a/s3/directory",
+            ... )
+        """
+        # Initialize a S3 client:
+        s3 = self._init_client()
+
+        # Look for all files beginning with the given key (`s3_path`):
+        files = self._get_files(s3_client=s3, s3_path=s3_path, bucket=bucket)
+
+        # If the list is empty, there is no such file:
+        if len(files) == 0:
+            raise FileNotFoundError(
+                f"There is no file at the bucket '{bucket}' named '{s3_path}'."
+            )
+
+        # Check if it's a single file or directory:
+        if len(files) == 1:
+            self._delete_file(
+                s3_client=s3,
+                s3_path=s3_path,
+                bucket=bucket,
+                verbose=verbose,
+            )
+        else:
+            self._delete_directory(
+                s3_client=s3,
+                s3_files_paths=files,
+                bucket=bucket,
+                verbose=verbose,
+            )
+        if verbose:
+            print("Done!")
+
+    def _init_client(self):
+        return boto3.client(
+            service_name="s3",
+            aws_access_key_id=self._aws_access_key_id,
+            aws_secret_access_key=self._aws_secret_access_key,
+        )
+
+    @staticmethod
+    def _get_files(s3_client, s3_path: str, bucket: str) -> List[str]:
+        return [
+            file["Key"]
+            for file in s3_client.list_objects(Bucket=bucket, Prefix=s3_path).get(
+                "Contents", []
+            )
+        ]
+
+    @staticmethod
+    def _upload_file(
+        s3_client,
+        local_path: str,
+        s3_path: str,
+        bucket: str,
+        replace: bool,
+        verbose: bool,
+    ):
+        # Check if needed to upload:
+        if replace:
+            upload = True  # `replace` is set to True:
+        else:
+            # Look for the file to know if its already exist:
+            files = S3Client._get_files(
+                s3_client=s3_client, s3_path=s3_path, bucket=bucket
+            )
+            if files:
+                upload = False  # `replace` is set to False as the file was found.
+            else:
+                upload = True  # The file was not found.
+
+        # Upload only if needed:
+        if upload:
+            if verbose:
+                print(f"Uploading '{local_path}' to {s3_path}")
+            s3_client.upload_file(Filename=local_path, Bucket=bucket, Key=s3_path)
+        elif verbose:
+            print(f"Skipping '{local_path}' as {s3_path} already exist")
+
+    @staticmethod
+    def _upload_directory(
+        s3_client,
+        local_path: str,
+        s3_path: str,
+        bucket: str,
+        replace: bool,
+        verbose: bool,
+    ):
+        # List all files in directory:
+        files = [
+            path
+            for path in glob.iglob(os.path.join(local_path, "**"), recursive=True)
+            if os.path.isfile(path)
+        ]
+        if len(files) == 0:
+            raise ValueError(
+                f"Found 0 files to upload as the given directory '{local_path}' is empty"
+            )
+
+        # Upload the files:
+        files_iterator = tqdm(files, desc="Uploading") if verbose else files
+        for file in files_iterator:
+            if verbose:
+                files_iterator.set_postfix({"file": file})
+            S3Client._upload_file(
+                s3_client=s3_client,
+                local_path=file,
+                s3_path=os.path.join(s3_path, os.path.relpath(file, local_path)),
+                bucket=bucket,
+                replace=replace,
+                verbose=SHELL is not None and verbose,
+            )
+
+    @staticmethod
+    def _download_file(
+        s3_client,
+        local_path: str,
+        s3_path: str,
+        bucket: str,
+        replace: bool,
+        verbose: bool,
+    ):
+        # Check if needed to download:
+        if replace:
+            download = True  # `replace` is set to True:
+        else:
+            # Look for the file to know if its already exist:
+            download = not os.path.exists(local_path)
+
+        # Download only if needed:
+        if download:
+            if verbose:
+                print(f"Downloading '{s3_path}' to {local_path}")
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            s3_client.download_file(Filename=local_path, Bucket=bucket, Key=s3_path)
+        elif verbose:
+            print(f"Skipping '{s3_path}' as {local_path} already exist")
+
+    @staticmethod
+    def _download_directory(
+        s3_client,
+        local_path: str,
+        s3_directory_path: str,
+        bucket: str,
+        s3_files_paths: List[str],
+        replace: bool,
+        verbose: bool,
+    ):
+        # Download the files:
+        files_iterator = (
+            tqdm(s3_files_paths, desc="Downloading") if verbose else s3_files_paths
+        )
+        for file in files_iterator:
+            if verbose:
+                files_iterator.set_postfix({"file": file})
+            S3Client._download_file(
+                s3_client=s3_client,
+                local_path=os.path.join(
+                    local_path, os.path.relpath(file, s3_directory_path)
+                ),
+                s3_path=file,
+                bucket=bucket,
+                replace=replace,
+                verbose=SHELL is not None and verbose,
+            )
+
+    @staticmethod
+    def _delete_file(
+        s3_client,
+        s3_path: str,
+        bucket: str,
+        verbose: bool,
+    ):
+        # Delete (only if the file is not versioned, otherwise it will just mark it as deleted in its latest version):
+        if verbose:
+            print(f"Deleting '{s3_path}'")
+        s3_client.delete_object(Bucket=bucket, Key=s3_path)
+
+    @staticmethod
+    def _delete_directory(
+        s3_client,
+        s3_files_paths: List[str],
+        bucket: str,
+        verbose: bool,
+    ):
+        # Delete the files:
+        files_iterator = (
+            tqdm(s3_files_paths, desc="Deleting") if verbose else s3_files_paths
+        )
+        for file in files_iterator:
+            if verbose:
+                files_iterator.set_postfix({"file": file})
+            S3Client._delete_file(
+                s3_client=s3_client,
+                s3_path=file,
+                bucket=bucket,
+                verbose=SHELL is not None and verbose,
+            )


### PR DESCRIPTION
Added `S3Client` in `utils` for handling files and directories to and from S3. In addition added two tests:
* `test-dask-s3` - Processing parquets and logging results and datasets to and from S3 using Dask.
* `test-dask-lightgbm` - Testing that Dask is working with MLRun and indeed training a LightGBM model using Dask is faster.