### PR TITLE
Add `pip install`s to notebooks

### DIFF
--- a/test-dask-lightgbm/test-dask-lightgbm.ipynb
+++ b/test-dask-lightgbm/test-dask-lightgbm.ipynb
@@ -31,6 +31,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Image versions: scikit-learn~=1.0 lightgbm~=3.0\n",
+    "# Test is set to install latest to make sure we are always up-to-date with the latest releases.\n",
+    "!pip install plotly scikit-learn lightgbm"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "5885bf29",
    "metadata": {

--- a/test-handler-decorator/test-handler-decorator.ipynb
+++ b/test-handler-decorator/test-handler-decorator.ipynb
@@ -46,8 +46,9 @@
    "execution_count": null,
    "outputs": [],
    "source": [
-    "# TODO: Remove in MLRun 1.3 as it the version will be correct\n",
-    "!pip install scikit-learn~=1.0.0"
+    "# Image versions: scikit-learn~=1.0\n",
+    "# Test is set to install latest to make sure we are always up-to-date with the latest releases.\n",
+    "!pip install matplotlib plotly scikit-learn"
    ],
    "metadata": {
     "collapsed": false,

--- a/test-horovod-pytorch/test-horovod-pytorch.ipynb
+++ b/test-horovod-pytorch/test-horovod-pytorch.ipynb
@@ -31,6 +31,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Image versions: torch==1.13.0 torchvision==0.14.0\n",
+    "# Test is set to install latest to make sure we are always up-to-date with the latest releases.\n",
+    "!pip install plotly torch torchvision"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "0793f908",
    "metadata": {

--- a/test-horovod-tensorflow/test-horovod-tensorflow.ipynb
+++ b/test-horovod-tensorflow/test-horovod-tensorflow.ipynb
@@ -31,6 +31,22 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Image versions: tensorflow==2.9.0\n",
+    "# Test is set to install latest to make sure we are always up-to-date with the latest releases.\n",
+    "!pip install plotly tensorflow"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "e190f156",
    "metadata": {


### PR DESCRIPTION
Add required `pip install`s of `scikit-learn`, `plotly`, `matplotlib`, `tensorflow`, `torch`, `torchvision` to notebooks to run on clean environments.