### PR TITLE
Changed the regex patter in 'remove_iter_from_uri' function because t…

### DIFF
--- a/test-mlflow-tracking/test-mlflow-tracking.ipynb
+++ b/test-mlflow-tracking/test-mlflow-tracking.ipynb
@@ -520,7 +520,7 @@
    "outputs": [],
    "source": [
     "def remove_iter_from_uri(uri):\n",
-    "    return re.sub(r'#\\d+', '', uri)"
+    "    return re.sub(r\"#\\d+:latest\", '', uri)"
    ]
   },
   {


### PR DESCRIPTION
…he uri now also includes the 'latest' tag. Now this function removes both